### PR TITLE
chore: add an entrypoint to run the tests with Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	go test -v -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -6,18 +6,13 @@ For details on how to bootstrap Testcontainers in an actual project, please refe
 
 ## Clone the repository and run the first Testcontainers test suite
 
-```
+```shell
 git clone https://github.com/AtomicJar/testcontainers-cloud-go-example
 cd testcontainers-cloud-go-example
-```
-
-## Run the test suite
-
-```shell
 make test
 ```
 
-The `Make` command will run the test suite using `go test -v -count=1 ./...`
+The `Make` command will run the test suite using `go test -v -count=1 ./...`.
 
 Note that it's important to add the `-v` flag to the `go test` command, otherwise the output of the tests will be suppressed.
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ cd testcontainers-cloud-go-example
 
 ## Run the test suite
 
-Note that it's important to add the `-v` flag to the `go test` command, otherwise the output of the tests will be suppressed.
-
 ```shell
-go test -v
+make test
 ```
+
+The `Make` command will run the test suite using `go test -v -count=1 ./...`
+
+Note that it's important to add the `-v` flag to the `go test` command, otherwise the output of the tests will be suppressed.
 
 ## Confirm your environment is configured correctly
 


### PR DESCRIPTION
## What does this PR do?
It adds an entrypoint using Make to run the tests with just a single command

## Why is it important?
It will implement the contract of all cloud examples to run tests with the very same command
 
