### PR TITLE
chore(ci): use go.mod and go.sum for caching Go dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
         - name: Setup Go
           uses: actions/setup-go@v4
           with:
-            go-version: '1.x'
+            go-version-file: 'go.mod'
+            cache-dependency-path: 'go.sum'
         - name: Setup Testcontainers Cloud Client
           uses: atomicjar/testcontainers-cloud-setup-action@main
           with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,3 @@ jobs:
         - name: Run example
           run: |
             make test
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
         - name: Run example
           run: |
             make test
+


### PR DESCRIPTION
It caches Go dependencies when installing Go with the GH action.