### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    update-types:
+    - "minor"
+    - "patch"


### PR DESCRIPTION
## What does this PR do?
It adds dependabot descriptor, monitoring Go deps.

## Why is it important?
Keep deps up-to-date, removing security issues on minor/patch releases
